### PR TITLE
[modified] Remove redundant 'v' prefix in release name

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -46,7 +46,7 @@ jobs:
           gh release delete $VERSION --cleanup-tag --yes --repo $GITHUB_REPOSITORY
           git tag -d $VERSION
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
       - name: Create and push version tag
         run: |
           git tag $VERSION

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -45,13 +45,7 @@ jobs:
           gh release delete $VERSION --cleanup-tag --yes --repo $GITHUB_REPOSITORY
           git tag -d $VERSION
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      - name: Create GitHub Release Draft
-        if: env.TAG_EXISTS == 'true'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.VERSION }}
-          name: Release ${{ env.VERSION }}
-          generate_release_notes: true
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ github.token }}
+      - name: Publish GitHub Release Draft
+        run: |
+          gh release create $VERSION --draft false --repo $GITHUB_REPOSITORY

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,7 +51,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.VERSION }}
-          name: Release v${{ env.VERSION }}
+          name: Release ${{ env.VERSION }}
           generate_release_notes: true
           draft: false
           prerelease: false


### PR DESCRIPTION
- Updated the 'name' field in the GitHub Actions workflow to remove the 'v' prefix in release names.