### PR TITLE
[modified] Remove duplicate release deletion step

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -39,13 +39,6 @@ jobs:
           else
             echo "TAG_EXISTS=false" >> $GITHUB_ENV
           fi
-      - name: Remove release if it already exists
-        if: env.TAG_EXISTS == 'true'
-        run: |
-          gh release delete $VERSION --cleanup-tag --yes --repo $GITHUB_REPOSITORY
-          git tag -d $VERSION
-        env:
-          GH_TOKEN: ${{ github.token }}
       - name: Publish GitHub Release Draft
         run: |
           gh release create $VERSION --draft false --repo $GITHUB_REPOSITORY


### PR DESCRIPTION
- Removed existing step that deletes a release and tag if it already exists in the GitHub repository before publishing a new release.
- Retained the step to publish the GitHub release draft.