### PR TITLE
release(workflow): include GH_TOKEN env in release job

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -41,3 +41,5 @@ jobs:
       - name: Publish GitHub Release Draft
         run: |
           gh release create $VERSION --draft false --repo $GITHUB_REPOSITORY
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The release workflow has been updated to include the GH_TOKEN environment variable as part of the publish GitHub release step.

- This change ensures that the release process has the necessary authentication to interact with the GitHub API
- It utilizes the GitHub Actions built-in `github.token` for secure access
- This update follows recommended best practices for authenticating GitHub CLI commands